### PR TITLE
fix: adds react 19 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "payment"
   ],
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "dependencies": {
     "credit-card-type": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "payment"
   ],
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react": ">=16.8.0 <= 19.x"
   },
   "dependencies": {
     "credit-card-type": "^9.1.0",


### PR DESCRIPTION
As far as I tested it works ok in react 19. So I am adding it to peerDeps so there is no warning and update scripts works smoothly.

I didn't pull from the react-credit-cards-2 repo (there are a few commits, it would be awesome to do it before releasing a new version)

PS: It would be awesome if you could enable Issues on this repo (since it's published in npm). Podria haberlo escrito en español ahora que me doy cuenta, pero bueno... Cualquier cosa avisame! Gracias por la lib! es un golazo!